### PR TITLE
[GITHUB ACTIONS] Show documents on test failure

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,3 +25,6 @@ jobs:
 
     - name: Test
       run: make test
+
+    - name: Log Docs
+      run: find ./ -type f | xargs tail -n +1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,5 +25,7 @@ jobs:
 
     - name: Test
       run: |
+        echo start
         make test
+        echo end
         find ./documents/ -type f | xargs tail -n +1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,4 +27,5 @@ jobs:
       run: make test
 
     - name: Log Docs
+      shell: bash
       run: find ./ -type f | xargs tail -n +1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,4 +28,5 @@ jobs:
 
     - name: Log Docs
       shell: bash
-      run: find ./ -type f | xargs tail -n +1
+      run: |
+        find ./ -type f | xargs tail -n +1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,5 +26,8 @@ jobs:
     - name: Test
       run: make test
 
-    - name: Log Docs
-      run: make log
+    - name: Archive documents
+      uses: actions/upload-artifact@v2
+      with:
+        name: documents
+        path: documents

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,9 +17,6 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
-    - name: Install
-      run: make install
-
     - name: Build
       run: make build
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,14 +17,13 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
+    - name: Install
+      run: make install
+
     - name: Build
       run: make build
 
     - name: Test
-      run: make test
-
-    - name: Archive documents
-      uses: actions/upload-artifact@v2
-      with:
-        name: documents
-        path: documents
+      run: |
+        make test
+        find ./documents/ -type f | xargs tail -n +1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,5 +27,4 @@ jobs:
       run: make test
 
     - name: Log Docs
-      shell: bash
-      run: find ./ -type f | xargs tail -n +1
+      run: make log

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
 
   build:
-    name: Build
+    name: Build_and_test
     runs-on: ubuntu-latest
     steps:
 
@@ -30,4 +30,5 @@ jobs:
       if: ${{ failure() }}
       run: |
         echo Documents reamining after failure...
-        find ./ -type f | xargs tail -n +1
+        find ./documents/ -type f | xargs tail -n +1
+        echo

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,8 +24,10 @@ jobs:
       run: make build
 
     - name: Test
+      run: make test
+
+    - name: Log Docs
+      if: ${{ failure() }}
       run: |
-        echo start
-        make test
-        echo end
-        find ./documents/ -type f | xargs tail -n +1
+        echo Documents reamining after failure...
+        find ./ -type f | xargs tail -n +1

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,5 @@ install:
 	go install .
 test:
 	go test -v .
+log:
+	find ./documents/ -type f | xargs tail -n +1

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,3 @@ install:
 	go install .
 test:
 	go test -v .
-log:
-	find ./documents/ -type f | xargs tail -n +1 && echo


### PR DESCRIPTION
This just makes it so documents left on disk are printed if the tests fail in the github actions. It affects no core code.